### PR TITLE
Renamed "quit" to "menu"

### DIFF
--- a/src/op-message/Message.tsx
+++ b/src/op-message/Message.tsx
@@ -76,7 +76,7 @@ export const Message: FC = function() {
         </Text>
       </View>
       <BottomNav animValue={fadeBottomAnim.value}>
-        <Button onPress={handleButtonPress} label="quit" />
+        <Button onPress={handleButtonPress} label="menu" />
       </BottomNav>
     </View>
   );

--- a/src/op-tutorial/Tutorial.tsx
+++ b/src/op-tutorial/Tutorial.tsx
@@ -96,7 +96,7 @@ export const Tutorial: FC = observer(function() {
       </View>
       {board.isInitialized && (
         <BottomNav animValue={fadeInterfaceAnim.value}>
-          <Button label="quit tutorial" onPress={handleQuitPress} />
+          <Button label="menu" onPress={handleQuitPress} />
         </BottomNav>
       )}
     </View>


### PR DESCRIPTION
Renamed the "quit" text of the "menu" button in both the tutorial and in the main game.
Solves #7