### PR TITLE
Added a "Statistics" screen

### DIFF
--- a/src/op-common/Button.tsx
+++ b/src/op-common/Button.tsx
@@ -3,31 +3,32 @@ import {
   StyleSheet,
   TouchableOpacity,
   StyleProp,
+  TouchableOpacityProps,
   ViewStyle
 } from "react-native";
 import { hapticFeedback, scale, playSound } from "op-utils";
-import { Text } from "./Text";
+import { Text, TextFamily, TextWeight } from "./Text";
 
 export const defaultButtonTextSize = scale(32);
 
-interface ButtonProps {
-  disabled?: boolean;
+interface ButtonProps extends TouchableOpacityProps {
   highlighted?: boolean;
   label: string;
-  onPress: () => void;
-  style?: StyleProp<ViewStyle>;
   textColor?: string;
+  textFamily?: TextFamily;
   textSize?: number;
+  textWeight?: TextWeight;
 }
 
 export const Button: FC<ButtonProps> = function({
   children,
-  disabled = false,
   highlighted = true,
   label,
-  onPress,
   style = {},
-  textSize = defaultButtonTextSize
+  textFamily,
+  textSize = defaultButtonTextSize,
+  textWeight = "semibold",
+  ...otherProps
 }) {
   const handlePressIn = () => {
     hapticFeedback.generate("impactMedium");
@@ -36,13 +37,13 @@ export const Button: FC<ButtonProps> = function({
   return (
     <TouchableOpacity
       style={[styles.touchable, style]}
-      onPress={onPress}
       onPressIn={handlePressIn}
-      disabled={disabled}
+      {...otherProps}
     >
       <Text
-        weight="semibold"
         secondary={!highlighted}
+        family={textFamily}
+        weight={textWeight}
         style={[
           styles.label,
           highlighted && styles.labelHighlighted,

--- a/src/op-common/Score.tsx
+++ b/src/op-common/Score.tsx
@@ -3,24 +3,44 @@ import { StyleSheet, Animated, ViewStyle } from "react-native";
 import { Text } from "op-common";
 import { scale } from "op-utils";
 import { animations } from "op-design";
+import { Button } from "./Button";
 
 interface ScoreProps {
   animValue: Animated.Value;
+  onPress?: () => void;
   score?: string | number;
   style?: ViewStyle;
 }
 
-export const Score: FC<ScoreProps> = function({ animValue, score, style }) {
+export const Score: FC<ScoreProps> = function({
+  animValue,
+  onPress,
+  score,
+  style
+}) {
   if (!score) return null;
+  const buttonHitSlop = {
+    top: scale(20),
+    bottom: scale(20),
+    left: scale(20),
+    right: scale(20)
+  };
   return (
     <Animated.View style={[styles.root, animations.fade(animValue), style]}>
-      <Text weight="semibold" family="secondary" style={styles.score}>
-        {String(score)}
-      </Text>
-      <Text weight="semibold" family="secondary" style={styles.star}>
-        {" "}
-        ★
-      </Text>
+      <Button
+        disabled={!onPress}
+        onPress={onPress}
+        hitSlop={buttonHitSlop}
+        label={String(score)}
+        textFamily="secondary"
+        textSize={scale(20)}
+        style={styles.content}
+      >
+        <Text weight="semibold" family="secondary" style={styles.star}>
+          {" "}
+          ★
+        </Text>
+      </Button>
     </Animated.View>
   );
 };
@@ -28,8 +48,9 @@ export const Score: FC<ScoreProps> = function({ animValue, score, style }) {
 const styles = StyleSheet.create({
   root: {
     position: "absolute",
-    flexDirection: "row",
-    alignSelf: "flex-end",
+    alignSelf: "flex-end"
+  },
+  content: {
     alignItems: "center"
   },
   score: {
@@ -39,3 +60,11 @@ const styles = StyleSheet.create({
     fontSize: scale(16)
   }
 });
+
+// <TouchableOpacity
+// disabled={!onPress}
+// onPress={() => null}
+// hitSlop={buttonHitSlop}
+// style={styles.content}
+// >
+// </TouchableOpacity>

--- a/src/op-common/Text.tsx
+++ b/src/op-common/Text.tsx
@@ -2,9 +2,13 @@ import React, { FC } from "react";
 import { TextProps as RNTextProps, StyleSheet, Animated } from "react-native";
 import { fonts, useColors } from "op-design";
 
+export type TextFamily = keyof typeof fonts;
+
+export type TextWeight = keyof typeof fonts.primary;
+
 export interface TextProps extends RNTextProps {
-  family?: keyof typeof fonts;
-  weight?: keyof typeof fonts.primary;
+  family?: TextFamily;
+  weight?: TextWeight;
   secondary?: boolean;
   style?: any; // Because on the missing "Animated" typings for the style
 }

--- a/src/op-core/Router.tsx
+++ b/src/op-core/Router.tsx
@@ -6,6 +6,7 @@ import { Intro } from "op-intro/Intro";
 import { Tutorial } from "op-tutorial/Tutorial";
 import { Message } from "op-message/Message";
 import { Success } from "op-success/Success";
+import { Stats } from "op-stats/Stats";
 import { useCoreStores } from "./store";
 
 export const Router: FC = observer(function() {
@@ -18,6 +19,8 @@ export const Router: FC = observer(function() {
     return <Game />;
   } else if (router.currentRoute === "success") {
     return <Success />;
+  } else if (router.currentRoute === "stats") {
+    return <Stats />;
   } else if (router.currentRoute === "tutorial") {
     if (puzzle.type === "message") {
       return <Message />;

--- a/src/op-core/store.ts
+++ b/src/op-core/store.ts
@@ -4,7 +4,13 @@ import { rehydrateObject, persistObject, pickRandomPuzzle } from "op-utils";
 import uniq from "lodash/uniq";
 import puzzles from "./puzzles.json";
 
-export type Route = "home" | "game" | "intro" | "tutorial" | "success";
+export type Route =
+  | "home"
+  | "game"
+  | "intro"
+  | "tutorial"
+  | "success"
+  | "stats";
 export type PuzzleMode = "tutorial" | "small" | "medium" | "large";
 
 const sum = (a: number, b: number) => a + b;
@@ -32,23 +38,20 @@ class RouterStore {
   @action
   changeRoute(route: Route, puzzleMode?: PuzzleMode | "continue") {
     switch (route) {
-      case "home": {
-        break;
-      }
       case "intro": {
         if (puzzleMode !== "continue") {
           this.root.puzzle.setRandomPuzzle(puzzleMode);
         }
         break;
       }
-      case "game": {
-        break;
-      }
-      case "success": {
-        break;
-      }
       case "tutorial": {
         this.root.puzzle.setPuzzle("tutorial", 0);
+        break;
+      }
+      case "home":
+      case "game":
+      case "success":
+      case "stats": {
         break;
       }
       default: {

--- a/src/op-home/Home.tsx
+++ b/src/op-home/Home.tsx
@@ -95,17 +95,22 @@ export const Home: FC = observer(function() {
     });
   }
 
+  // Score setup
   const scoreStyle: ViewStyle = {
     top: -metrics.screenMargin
+  };
+  const handleScorePress = () => {
+    if (isMenuDisabled) return;
+    setIsMenuDisabled(true);
+    rootFadeAnim
+      .setup({ duration: rootFadeOutAnimDuration, toValue: 0 })
+      .start(() => {
+        router.changeRoute("stats");
+      });
   };
 
   return (
     <Animated.View style={[styles.root, animations.fade(rootFadeAnim.value)]}>
-      <Score
-        animValue={menuAnim.value}
-        score={stats.score}
-        style={scoreStyle}
-      />
       <View style={styles.top}>
         <Logo titleAnimValue={titleAnim.value} dotAnimValue={dotAnim.value} />
       </View>
@@ -116,6 +121,12 @@ export const Home: FC = observer(function() {
           items={menuItems}
         />
       </View>
+      <Score
+        animValue={menuAnim.value}
+        onPress={isMenuDisabled ? undefined : handleScorePress}
+        score={stats.score}
+        style={scoreStyle}
+      />
     </Animated.View>
   );
 });

--- a/src/op-stats/Stats.tsx
+++ b/src/op-stats/Stats.tsx
@@ -1,0 +1,93 @@
+import React, { FC, useRef } from "react";
+import { StyleSheet, Animated } from "react-native";
+import { observer } from "mobx-react";
+import { useCoreStores } from "op-core";
+import { BottomNav, Button, Text, bottomNavHeight } from "op-common";
+import { metrics, animations } from "op-design";
+import {
+  useAnimation,
+  useOnMount,
+  scale,
+  useHardwareBackButton
+} from "op-utils";
+
+export const Stats: FC = observer(function() {
+  const { stats, router } = useCoreStores();
+  const interactionsDisabledRef = useRef(false);
+
+  // Routing setup
+  const navigateToHome = () => router.changeRoute("home");
+  useHardwareBackButton(navigateToHome);
+
+  // Animations setup
+  const fadeRootInAnimDuration = 400;
+  const fadeRootOutAnimDuration = 200;
+  const fadeRootAnim = useAnimation(0);
+  const fadeRootIn = () =>
+    fadeRootAnim.setup({ duration: fadeRootInAnimDuration });
+  const fadeRootOut = () =>
+    fadeRootAnim.setup({ duration: fadeRootOutAnimDuration, toValue: 0 });
+
+  useOnMount(() => {
+    fadeRootIn().start();
+  });
+
+  // Callback handlers
+  const handleMenuPress = () => {
+    if (interactionsDisabledRef.current) return;
+    interactionsDisabledRef.current = true;
+    fadeRootOut().start(() => {
+      navigateToHome();
+    });
+  };
+
+  return (
+    <Animated.View style={styles.root}>
+      <Animated.View
+        style={[styles.middle, animations.fade(fadeRootAnim.value)]}
+      >
+        <Text weight="bold" style={styles.title}>
+          Statistics
+        </Text>
+        <Text weight="semibold" style={styles.progress}>
+          small: {stats.completedPuzzles["small"].length}/99
+        </Text>
+        <Text weight="semibold" style={styles.progress}>
+          medium: {stats.completedPuzzles["medium"].length}/99
+        </Text>
+        <Text weight="semibold" style={styles.progress}>
+          large: {stats.completedPuzzles["large"].length}/99
+        </Text>
+        <Text weight="bold" style={styles.score}>
+          score: {stats.score}
+        </Text>
+      </Animated.View>
+      <BottomNav animValue={fadeRootAnim.value}>
+        <Button label="Menu" onPress={handleMenuPress} />
+      </BottomNav>
+    </Animated.View>
+  );
+});
+
+const styles = StyleSheet.create({
+  root: {
+    height: "100%",
+    marginHorizontal: metrics.screenMargin
+  },
+  middle: {
+    flex: 1,
+    marginTop: bottomNavHeight,
+    justifyContent: "center"
+  },
+  title: {
+    fontSize: scale(48)
+  },
+  score: {
+    fontSize: scale(36),
+    marginTop: scale(36)
+  },
+  progress: {
+    fontSize: scale(36),
+    marginTop: scale(14)
+  }
+});

--- a/src/op-stats/index.ts
+++ b/src/op-stats/index.ts
@@ -1,0 +1,1 @@
+export * from "./Stats";


### PR DESCRIPTION
Added a "Statistics" screen that shows the puzzles completions progress.
The screen is accessible by tapping the score on the top right of the screen.

<img width="432" alt="Screenshot 2019-12-23 at 12 22 49" src="https://user-images.githubusercontent.com/9536354/71355698-267d2a00-2580-11ea-939b-8b736f042bd2.png">
<img width="650" alt="Screenshot 2019-12-23 at 12 23 57" src="https://user-images.githubusercontent.com/9536354/71355703-2846ed80-2580-11ea-8226-31015fcce237.png">
